### PR TITLE
A fix to keep blog current year dropdown open

### DIFF
--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -36,6 +36,12 @@
     </ul>
   </nav>
 </div>
+
+<script>
+  $(function() {
+    $(".td-sidebar-nav__section > input").first().prop('checked', true);
+  });
+</script>
 {{ define "section-tree-nav-section" -}}
 {{ $s := .section -}}
 {{ $p := .page -}}


### PR DESCRIPTION
This will fix a issue to keep blog current year dropdown open that was opened on https://github.com/open-telemetry/opentelemetry.io/issues/3415